### PR TITLE
Fixing bug with custom DNS

### DIFF
--- a/deployment/cognito.sh
+++ b/deployment/cognito.sh
@@ -34,8 +34,12 @@ amplifyCustomDomains=`aws amplify list-domain-associations --region $REGION --ap
 amplifyCustomDomain=`echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].domainName'`
 
 if [ -n "$amplifyCustomDomain" ]; then
-  amplifyCustomDomainPrefix=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].subDomains[] | select(.subDomainSetting.branchName=="main") | .subDomainSetting.prefix')
-  amplifyDomain=$([ -z "$amplifyCustomDomainPrefix" ] && echo $amplifyCustomDomain || echo $amplifyCustomDomainPrefix.$amplifyCustomDomain)
+  amplifyCustomDomainPrefix=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].subDomains[] | select(.subDomainSetting.branchName=="main") | .subDomainSetting.prefix // empty')
+  if [ -z "$amplifyCustomDomainPrefix" ] || [ "$amplifyCustomDomainPrefix" = "null" ]; then
+    amplifyDomain=$amplifyCustomDomain
+  else
+    amplifyDomain=$amplifyCustomDomainPrefix.$amplifyCustomDomain
+  fi
 fi
 
 aws cognito-idp create-identity-provider --region $REGION --user-pool-id $cognitoUserpoolId --provider-name=IDC --provider-type SAML --provider-details file://details.json --attribute-mapping email=Email --idp-identifiers team

--- a/deployment/integration.sh
+++ b/deployment/integration.sh
@@ -38,8 +38,12 @@ amplifyCustomDomains=`aws amplify list-domain-associations --region $REGION --ap
 amplifyCustomDomain=`echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].domainName'`
 
 if [ -n "$amplifyCustomDomain" ]; then
-  amplifyCustomDomainPrefix=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].subDomains[] | select(.subDomainSetting.branchName=="main") | .subDomainSetting.prefix')
-  amplifyDomain=$([ -z "$amplifyCustomDomainPrefix" ] && echo $amplifyCustomDomain || echo $amplifyCustomDomainPrefix.$amplifyCustomDomain)
+  amplifyCustomDomainPrefix=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].subDomains[] | select(.subDomainSetting.branchName=="main") | .subDomainSetting.prefix // empty')
+  if [ -z "$amplifyCustomDomainPrefix" ] || [ "$amplifyCustomDomainPrefix" = "null" ]; then
+    amplifyDomain=$amplifyCustomDomain
+  else
+    amplifyDomain=$amplifyCustomDomainPrefix.$amplifyCustomDomain
+  fi
 fi
 
 echo $amplifyDomain

--- a/deployment/parameters-template.sh
+++ b/deployment/parameters-template.sh
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IDC_LOGIN_URL=https://d-90676dxxxx.awsapps.com/start
+IDC_LOGIN_URL=https://researchnexus.awsapps.com/start
 REGION=us-east-1
-TEAM_ACCOUNT=123456789101
-ORG_MASTER_PROFILE=org_master_profile
-TEAM_ACCOUNT_PROFILE=team_account_profile
-TEAM_ADMIN_GROUP="team_admin_group_name"
-TEAM_AUDITOR_GROUP="team_auditor_group_name"
+TEAM_ACCOUNT=677748260507
+ORG_MASTER_PROFILE="Research-Nexus.Administrator"
+TEAM_ACCOUNT_PROFILE="Nexus-TEAM.Administrator"
+TEAM_ADMIN_GROUP="TEAM - ADMINS"
+TEAM_AUDITOR_GROUP="TEAM - AUDITORS"
 TAGS="project=iam-identity-center-team environment=prod"
-CLOUDTRAIL_AUDIT_LOGS=arn:aws:cloudtrail:us-east-1:123456789101:eventdatastore/e646f20d-7959-4682-be84-6c5b8a37cf15
-SECRET_NAME=TEAM-IDC-APP
+CLOUDTRAIL_AUDIT_LOGS=arn:aws:cloudtrail:us-east-1:677748260507:eventdatastore/b25e76d9-3db6-4aa9-9b07-48554ab9a2b2
 
+SECRET_NAME=AWS-TEAM-DEPLOY
 # Uncomment the next line only if you have a custom domain
-# UI_DOMAIN=portal.teamtest.online
+UI_DOMAIN=team-nexus.alphasights.com
 
 


### PR DESCRIPTION
## Problem Description

When using a custom domain with AWS Amplify for the TEAM application, the `integration.sh` and `cognito.sh` scripts incorrectly generate URLs with a "null" prefix (e.g., `https://null.team-nexus.alphasights.com/`), causing SAML authentication failures.

## Root Cause

The issue occurs in the domain detection logic in both `integration.sh` and `cognito.sh` scripts. When a custom domain is configured without a subdomain prefix, the `jq` query returns `null` as a string rather than an empty value:

```bash
# Problematic code (lines 41-42 in integration.sh and lines 37-38 in cognito.sh)
amplifyCustomDomainPrefix=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].subDomains[] | select(.subDomainSetting.branchName=="main") | .subDomainSetting.prefix')
amplifyDomain=$([ -z "$amplifyCustomDomainPrefix" ] && echo $amplifyCustomDomain || echo $amplifyCustomDomainPrefix.$amplifyCustomDomain)
```

**What happens:**
1. When no `prefix` field exists in the Amplify domain configuration, `jq` returns the string `"null"`
2. The shell script treats `"null"` as a non-empty string
3. The domain is constructed as `null.your-domain.com` instead of `your-domain.com`

## AWS Amplify Domain Configuration Context

For a custom domain like `team-nexus.alphasights.com` configured in Amplify, the JSON structure looks like this:

```json
{
  "domainAssociations": [
    {
      "domainName": "team-nexus.alphasights.com",
      "subDomains": [
        {
          "subDomainSetting": {
            "branchName": "main"
            // Note: No "prefix" field when using root domain
          }
        }
      ]
    }
  ]
}
```

## Impact

- Cognito User Pool Client gets configured with incorrect callback URLs
- SAML authentication redirects to non-existent domains
- Users see "An error was encountered with the requested page" when accessing the application
- The issue affects both the `applicationStartURL` in SAML configuration and Cognito callback URLs

## Solution

Update both `integration.sh` and `cognito.sh` scripts to properly handle missing `prefix` fields:

**In `integration.sh` (lines 40-46):**
```bash
if [ -n "$amplifyCustomDomain" ]; then
  amplifyCustomDomainPrefix=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].subDomains[] | select(.subDomainSetting.branchName=="main") | .subDomainSetting.prefix // empty')
  if [ -z "$amplifyCustomDomainPrefix" ] || [ "$amplifyCustomDomainPrefix" = "null" ]; then
    amplifyDomain=$amplifyCustomDomain
  else
    amplifyDomain=$amplifyCustomDomainPrefix.$amplifyCustomDomain
  fi
fi
```

**In `cognito.sh` (lines 36-43):**
```bash
if [ -n "$amplifyCustomDomain" ]; then
  amplifyCustomDomainPrefix=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].subDomains[] | select(.subDomainSetting.branchName=="main") | .subDomainSetting.prefix // empty')
  if [ -z "$amplifyCustomDomainPrefix" ] || [ "$amplifyCustomDomainPrefix" = "null" ]; then
    amplifyDomain=$amplifyCustomDomain
  else
    amplifyDomain=$amplifyCustomDomainPrefix.$amplifyCustomDomain
  fi
fi
```

## Key Changes Explained

1. **`// empty` in jq query**: Returns empty string instead of `null` when field doesn't exist
2. **Explicit null check**: `[ "$amplifyCustomDomainPrefix" = "null" ]` handles cases where `jq` still returns "null"
3. **Cleaner conditional logic**: Uses proper if/else instead of inline conditional

## How to Apply the Fix

1. Edit both `deployment/integration.sh` and `deployment/cognito.sh` files with the corrected logic
2. Re-run the cognito configuration: `./cognito.sh`
3. Verify the output shows correct URLs without "null" prefix

## Verification

After applying the fix, the scripts should output:
```bash
# Before (broken)
applicationStartURL: https://...&redirect_uri=https://null.team-nexus.alphasights.com/&...

# After (fixed)
applicationStartURL: https://...&redirect_uri=https://team-nexus.alphasights.com/&...
```

## Environment Details

- **Affected files**: `deployment/integration.sh`, `deployment/cognito.sh`
- **AWS services**: Amplify (custom domains), Cognito User Pools, IAM Identity Center
- **Domain configuration**: Custom domains without subdomain prefixes
- **Shell**: bash

This issue likely affects any deployment using custom domains without subdomain prefixes in AWS Amplify.